### PR TITLE
DeliveryModule wasn't correctly retrieved.

### DIFF
--- a/Controller/PayPalResponseController.php
+++ b/Controller/PayPalResponseController.php
@@ -384,7 +384,11 @@ class PayPalResponseController extends OrderController
             $deliveryAddress = $cart->getCustomer()->getDefaultAddress();
 
             /** @var \Thelia\Model\Module $deliveryModule */
-            $deliveryModule = ModuleQuery::create()->filterByActivate(1)->findOne();
+            $order = $this->getSession()->getOrder();
+            if (null !== $order) {
+                $deliveryModule = $order->getModuleRelatedByDeliveryModuleId();
+            }
+            
             /** @var \Thelia\Model\Module $paymentModule */
             $paymentModule = ModuleQuery::create()->findPk(PayPal::getModuleId());
 


### PR DESCRIPTION
Previously, the function was getting the first active module, even if it wasn't a delivery module.
Therefore, postage data retrieving (occurring line 414) was returning a "Cannot commit because a nested transaction was rolled back" error.

Now, we get the right delivery module, directly from the order.